### PR TITLE
Prepare dart/crypto library for limiting integers to 64 bits in Dart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.2
+
+* Prepare `HashSink` implementation for limiting integers to 64 bits in Dart
+  language.
+
 ## 2.0.1
 
 * Support `convert` 2.0.0.

--- a/lib/src/hash_sink.dart
+++ b/lib/src/hash_sink.dart
@@ -25,6 +25,10 @@ abstract class HashSink implements Sink<List<int>> {
   /// used across invocations of [_iterate].
   final Uint32List _currentChunk;
 
+  /// Messages with more than 2^64-1 bits are not supported.
+  /// So the maximum length in bytes is (2^64-1)/8.
+  static const _maxMessageLengthInBytes = 0x1fffffffffffffff;
+
   /// The length of the input data so far, in bytes.
   int _lengthInBytes = 0;
 
@@ -121,8 +125,7 @@ abstract class HashSink implements Sink<List<int>> {
       _pendingData.add(0);
     }
 
-    const maxMessageLengthInBytes = ((1 << (64 - bitsPerByte)) - 1);
-    if (_lengthInBytes > maxMessageLengthInBytes) {
+    if (_lengthInBytes > _maxMessageLengthInBytes) {
       throw new UnsupportedError(
           "Hashing is unsupported for messages with more than 2^64 bits.");
     }

--- a/lib/src/hash_sink.dart
+++ b/lib/src/hash_sink.dart
@@ -121,11 +121,13 @@ abstract class HashSink implements Sink<List<int>> {
       _pendingData.add(0);
     }
 
-    var lengthInBits = _lengthInBytes * bitsPerByte;
-    if (lengthInBits > maxUint64) {
+    const maxMessageLengthInBytes = ((1 << (64 - bitsPerByte)) - 1);
+    if (_lengthInBytes > maxMessageLengthInBytes) {
       throw new UnsupportedError(
           "Hashing is unsupported for messages with more than 2^64 bits.");
     }
+
+    var lengthInBits = _lengthInBytes * bitsPerByte;
 
     // Add the full length of the input data as a 64-bit value at the end of the
     // hash.

--- a/lib/src/utils.dart
+++ b/lib/src/utils.dart
@@ -5,9 +5,6 @@
 /// A bitmask that limits an integer to 32 bits.
 const mask32 = 0xFFFFFFFF;
 
-/// The highest value representable by a 64-bit unsigned integer.
-const maxUint64 = 0xFFFFFFFFFFFFFFFF;
-
 /// The number of bits in a byte.
 const bitsPerByte = 8;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: crypto
-version: 2.0.3-dev
+version: 2.0.2
 author: Dart Team <misc@dartlang.org>
 description: Library of cryptographic functions.
 homepage: https://www.github.com/dart-lang/crypto

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: crypto
-version: 2.0.2-dev
+version: 2.0.3-dev
 author: Dart Team <misc@dartlang.org>
 description: Library of cryptographic functions.
 homepage: https://www.github.com/dart-lang/crypto


### PR DESCRIPTION
In future, we consider limiting integers in Dart to 64 bits.
After this Dart language change, the integer literals like
0xFFFFFFFFFFFFFFFF will be rejected.
This CL removes such literal from Crypto library and replaces its use
with equivalent code without overflow.
