### PR TITLE
Remove 64 bit int constant so that dart2js can compile with crypto.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 2.0.4
+
+* Made max message size a BigNum instead of an int so that dart2js can compile
+  with crypto.
+
 ## 2.0.3
 
 * Updated SDK version to 2.0.0-dev.17.0

--- a/lib/src/hash_sink.dart
+++ b/lib/src/hash_sink.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:typed_data';
+import 'dart:math' as math;
 
 import 'package:typed_data/typed_data.dart';
 
@@ -24,10 +25,6 @@ abstract class HashSink implements Sink<List<int>> {
   /// This is an instance variable to avoid re-allocating, but its data isn't
   /// used across invocations of [_iterate].
   final Uint32List _currentChunk;
-
-  /// Messages with more than 2^64-1 bits are not supported.
-  /// So the maximum length in bytes is (2^64-1)/8.
-  static const _maxMessageLengthInBytes = 0x1fffffffffffffff;
 
   /// The length of the input data so far, in bytes.
   int _lengthInBytes = 0;
@@ -124,7 +121,10 @@ abstract class HashSink implements Sink<List<int>> {
       _pendingData.add(0);
     }
 
-    if (_lengthInBytes > _maxMessageLengthInBytes) {
+    if (new BigInt.from(_lengthInBytes) >
+        (new BigInt.from(2).pow(64) - BigInt.one)) {
+      // Messages with more than 2^64-1 bits are not supported.
+      // So the maximum length in bytes is (2^64-1)/8.
       throw new UnsupportedError(
           'Hashing is unsupported for messages with more than 2^64 bits.');
     }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: crypto
-version: 2.0.3
+version: 2.0.4
 author: Dart Team <misc@dartlang.org>
 description: Library of cryptographic functions.
 homepage: https://www.github.com/dart-lang/crypto


### PR DESCRIPTION
This change.... is so hair-brained I just can't even.....

The context is dart2js now has full JS number semantics, so it will cough on numbers that are not precisely representable as a double (generally > 2^53). I got around that by making this a BigNum, but it's pretty idiotic. I welcome alternatives. :-/