### PR TITLE
SHA 512/384 padding is 128 bit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 2.1.4
+  * BugFix: padding was incorrect for some SHA-512/328.
+
 ## 2.1.3
   * **Security vulnerability**: Fixed constant-time comparison in `Digest`.
 

--- a/lib/src/hash_sink.dart
+++ b/lib/src/hash_sink.dart
@@ -45,7 +45,7 @@ abstract class HashSink implements Sink<List<int>> {
   Uint32List get digest;
 
   /// The length
-  int get signatureByteSize => 8;
+  int get signatureBytes => 8;
 
   /// Creates a new hash.
   ///
@@ -125,7 +125,7 @@ abstract class HashSink implements Sink<List<int>> {
     // as we need to land cleanly on a chunk boundary.
     _pendingData.add(0x80);
 
-    final contentsLength = _lengthInBytes + 1 /* 0x80 */ + signatureByteSize;
+    final contentsLength = _lengthInBytes + 1 /* 0x80 */ + signatureBytes;
     final finalizedLength =
         _roundUp(contentsLength, _currentChunk.lengthInBytes);
 
@@ -143,9 +143,9 @@ abstract class HashSink implements Sink<List<int>> {
     // Add the full length of the input data as a 64-bit value at the end of the
     // hash. Note: we're only writing out 64 bits, so skip ahead 8 if the
     // signature is 128-bit.
-    final offset = _pendingData.length + (signatureByteSize - 8);
+    final offset = _pendingData.length + (signatureBytes - 8);
 
-    _pendingData.addAll(Uint8List(signatureByteSize));
+    _pendingData.addAll(Uint8List(signatureBytes));
     var byteData = _pendingData.buffer.asByteData();
 
     // We're essentially doing byteData.setUint64(offset, lengthInBits, _endian)

--- a/lib/src/sha512_fastsinks.dart
+++ b/lib/src/sha512_fastsinks.dart
@@ -8,7 +8,6 @@ import 'digest.dart';
 import 'hash_sink.dart';
 
 abstract class _Sha64BitSink extends HashSink {
-
   @override
   int get signatureBytes => 16;
 

--- a/lib/src/sha512_fastsinks.dart
+++ b/lib/src/sha512_fastsinks.dart
@@ -8,9 +8,6 @@ import 'digest.dart';
 import 'hash_sink.dart';
 
 abstract class _Sha64BitSink extends HashSink {
-  @override
-  int get signatureBytes => 16;
-
   int get digestBytes;
 
   @override
@@ -33,7 +30,8 @@ abstract class _Sha64BitSink extends HashSink {
   /// used across invocations of [updateHash].
   final _extended = Uint64List(80);
 
-  _Sha64BitSink(Sink<Digest> sink, this._digest) : super(sink, 32);
+  _Sha64BitSink(Sink<Digest> sink, this._digest)
+      : super(sink, 32, signatureBytes: 16);
   // The following helper functions are taken directly from
   // http://tools.ietf.org/html/rfc6234.
 

--- a/lib/src/sha512_fastsinks.dart
+++ b/lib/src/sha512_fastsinks.dart
@@ -8,6 +8,10 @@ import 'digest.dart';
 import 'hash_sink.dart';
 
 abstract class _Sha64BitSink extends HashSink {
+
+  @override
+  int get signatureByteSize => 16;
+
   int get digestBytes;
 
   @override

--- a/lib/src/sha512_fastsinks.dart
+++ b/lib/src/sha512_fastsinks.dart
@@ -10,7 +10,7 @@ import 'hash_sink.dart';
 abstract class _Sha64BitSink extends HashSink {
 
   @override
-  int get signatureByteSize => 16;
+  int get signatureBytes => 16;
 
   int get digestBytes;
 

--- a/lib/src/sha512_slowsinks.dart
+++ b/lib/src/sha512_slowsinks.dart
@@ -54,9 +54,6 @@ final _noise32 = Uint32List.fromList([
 ]);
 
 abstract class _Sha64BitSink extends HashSink {
-  @override
-  int get signatureBytes => 16;
-
   int get digestBytes;
 
   @override
@@ -74,7 +71,8 @@ abstract class _Sha64BitSink extends HashSink {
   /// used across invocations of [updateHash].
   final _extended = Uint32List(160);
 
-  _Sha64BitSink(Sink<Digest> sink, this._digest) : super(sink, 32);
+  _Sha64BitSink(Sink<Digest> sink, this._digest)
+      : super(sink, 32, signatureBytes: 16);
   // The following helper functions are taken directly from
   // http://tools.ietf.org/html/rfc6234.
 

--- a/lib/src/sha512_slowsinks.dart
+++ b/lib/src/sha512_slowsinks.dart
@@ -54,6 +54,9 @@ final _noise32 = Uint32List.fromList([
 ]);
 
 abstract class _Sha64BitSink extends HashSink {
+  @override
+  int get signatureBytes => 16;
+
   int get digestBytes;
 
   @override

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: crypto
-version: 2.1.3
+version: 2.1.4
 author: Dart Team <misc@dartlang.org>
 description: Library of cryptographic functions.
 homepage: https://www.github.com/dart-lang/crypto

--- a/test/sha512_test.dart
+++ b/test/sha512_test.dart
@@ -75,5 +75,27 @@ void main() {
         outer.close();
       });
     });
+
+    test('128 bit padding', () {
+      final salts = [
+        'AAAA{3FXhiiyc5gGWlRrVQ2RlJ.6xj.DKvf6l0bJxqh0BzA}'.codeUnits,
+        'AAAA{3FXhiiyc5gGWlRrVQ.2RlJ6xj.DKvf6l0bJxqh0BzA}'.codeUnits,
+        'AAAA{rFXhiiyc5gGWlVQ.2RlJ6xj.DKvf6lFXhiiyc5gGWl0}'.codeUnits,
+      ];
+
+      const results = [
+        'nYg7eEsF/P7/l1AO0w8JFNNomS1gC76VE7Eg7Dpet+Dh6XiScDntYEU4tVItXp67evaLFvtMpW2uVJBZVKrBPw==',
+        'TXNM4uk1Iwr2cYisWSdFifXdjfNiJTGEmNaMtqYrwJoS3JXpL1rebPKPfKudbFQGpcgJkLLhhpfnLzULBqq8KA==',
+        'ckPYMDuPJjc73qHXQZiJgCskNG8mj9cPqFNsqYqxcBbQESgkWChoibAN7ssJrnoMFIpz9HwsBwMtt3z/KDUh9w==',
+      ];
+
+      for (int i = 0; i < salts.length; i++) {
+        var digest = <int>[];
+        for (int run = 0; run < 2000; run++) {
+          digest = sha512.convert([]..addAll(digest)..addAll(salts[i])).bytes;
+        }
+        expect(base64.encode(digest), results[i]);
+      }
+    });
   });
 }


### PR DESCRIPTION
The SHA algorithms were fine; but the padding in HashSink was hardcoded
to 64-bit signatures. While we still only generate a 64-bit signature,
the signature space is 128-bit.

Fixes #69.

Special thanks to @Nico04 for providing the test cases that lead to this
discovery.