### PR TITLE
Fix newly enforced package:pedantic lints

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: dart
 
 dart:
-  - 2.1.0
+  - 2.3.0
   - stable 
 
 dart_task:

--- a/lib/src/digest.dart
+++ b/lib/src/digest.dart
@@ -25,8 +25,8 @@ class Digest {
         return false;
       }
       final n = a.length;
-      int mismatch = 0;
-      for (int i = 0; i < n; i++) {
+      var mismatch = 0;
+      for (var i = 0; i < n; i++) {
         mismatch |= a[i] ^ b[i];
       }
       return mismatch == 0;

--- a/lib/src/sha512.dart
+++ b/lib/src/sha512.dart
@@ -52,6 +52,7 @@ class Sha384 extends Hash {
 class Sha512 extends Sha384 {
   Sha512._() : super._();
 
+  @override
   Sha512 newInstance() => Sha512._();
 
   @override

--- a/lib/src/sha512_fastsinks.dart
+++ b/lib/src/sha512_fastsinks.dart
@@ -14,7 +14,7 @@ abstract class _Sha64BitSink extends HashSink {
   Uint32List get digest {
     var unordered = _digest.buffer.asUint32List();
     var ordered = Uint32List(digestBytes);
-    for (int i = 0; i < digestBytes; i++) {
+    for (var i = 0; i < digestBytes; i++) {
       ordered[i] = unordered[i + (i.isEven ? 1 : -1)];
     }
     return ordered;

--- a/lib/src/sha512_slowsinks.dart
+++ b/lib/src/sha512_slowsinks.dart
@@ -76,7 +76,8 @@ abstract class _Sha64BitSink extends HashSink {
   // The following helper functions are taken directly from
   // http://tools.ietf.org/html/rfc6234.
 
-  _shr(int bits, Uint32List word, int offset, Uint32List ret, int offsetR) {
+  void _shr(
+      int bits, Uint32List word, int offset, Uint32List ret, int offsetR) {
     ret[0 + offsetR] =
         ((bits < 32) && (bits >= 0)) ? (word[0 + offset] >> (bits)) : 0;
     ret[1 + offsetR] = (bits > 32)
@@ -89,7 +90,8 @@ abstract class _Sha64BitSink extends HashSink {
                 : 0;
   }
 
-  _shl(int bits, Uint32List word, int offset, Uint32List ret, int offsetR) {
+  void _shl(
+      int bits, Uint32List word, int offset, Uint32List ret, int offsetR) {
     ret[0 + offsetR] = (bits > 32)
         ? (word[1 + offset] << (bits - 32))
         : (bits == 32)
@@ -102,19 +104,19 @@ abstract class _Sha64BitSink extends HashSink {
         ((bits < 32) && (bits >= 0)) ? (word[1 + offset] << bits) : 0;
   }
 
-  _or(Uint32List word1, int offset1, Uint32List word2, int offset2,
+  void _or(Uint32List word1, int offset1, Uint32List word2, int offset2,
       Uint32List ret, int offsetR) {
     ret[0 + offsetR] = word1[0 + offset1] | word2[0 + offset2];
     ret[1 + offsetR] = word1[1 + offset1] | word2[1 + offset2];
   }
 
-  _xor(Uint32List word1, int offset1, Uint32List word2, int offset2,
+  void _xor(Uint32List word1, int offset1, Uint32List word2, int offset2,
       Uint32List ret, int offsetR) {
     ret[0 + offsetR] = word1[0 + offset1] ^ word2[0 + offset2];
     ret[1 + offsetR] = word1[1 + offset1] ^ word2[1 + offset2];
   }
 
-  _add(Uint32List word1, int offset1, Uint32List word2, int offset2,
+  void _add(Uint32List word1, int offset1, Uint32List word2, int offset2,
       Uint32List ret, int offsetR) {
     ret[1 + offsetR] = (word1[1 + offset1] + word2[1 + offset2]);
     ret[0 + offsetR] = word1[0 + offset1] +
@@ -122,7 +124,7 @@ abstract class _Sha64BitSink extends HashSink {
         (ret[1 + offsetR] < word1[1 + offset1] ? 1 : 0);
   }
 
-  _addTo2(Uint32List word1, int offset1, Uint32List word2, int offset2) {
+  void _addTo2(Uint32List word1, int offset1, Uint32List word2, int offset2) {
     int _addTemp;
     _addTemp = word1[1 + offset1];
     word1[1 + offset1] += word2[1 + offset2];
@@ -152,13 +154,14 @@ abstract class _Sha64BitSink extends HashSink {
   final _nums = Uint32List(12 + 16 + 10);
 
   // SHA rotate   ((word >> bits) | (word << (64-bits)))
-  _rotr(int bits, Uint32List word, int offset, Uint32List ret, int offsetR) {
+  void _rotr(
+      int bits, Uint32List word, int offset, Uint32List ret, int offsetR) {
     _shr(bits, word, offset, _nums, _rotrIndex1);
     _shl(64 - bits, word, offset, _nums, _rotrIndex2);
     _or(_nums, _rotrIndex1, _nums, _rotrIndex2, ret, offsetR);
   }
 
-  _bsig0(Uint32List word, int offset, Uint32List ret, int offsetR) {
+  void _bsig0(Uint32List word, int offset, Uint32List ret, int offsetR) {
     _rotr(28, word, offset, _nums, _sigIndex1);
     _rotr(34, word, offset, _nums, _sigIndex2);
     _rotr(39, word, offset, _nums, _sigIndex3);
@@ -166,7 +169,7 @@ abstract class _Sha64BitSink extends HashSink {
     _xor(_nums, _sigIndex1, _nums, _sigIndex4, ret, offsetR);
   }
 
-  _bsig1(Uint32List word, int offset, Uint32List ret, int offsetR) {
+  void _bsig1(Uint32List word, int offset, Uint32List ret, int offsetR) {
     _rotr(14, word, offset, _nums, _sigIndex1);
     _rotr(18, word, offset, _nums, _sigIndex2);
     _rotr(41, word, offset, _nums, _sigIndex3);
@@ -174,7 +177,7 @@ abstract class _Sha64BitSink extends HashSink {
     _xor(_nums, _sigIndex1, _nums, _sigIndex4, ret, offsetR);
   }
 
-  _ssig0(Uint32List word, int offset, Uint32List ret, int offsetR) {
+  void _ssig0(Uint32List word, int offset, Uint32List ret, int offsetR) {
     _rotr(1, word, offset, _nums, _sigIndex1);
     _rotr(8, word, offset, _nums, _sigIndex2);
     _shr(7, word, offset, _nums, _sigIndex3);
@@ -182,7 +185,7 @@ abstract class _Sha64BitSink extends HashSink {
     _xor(_nums, _sigIndex1, _nums, _sigIndex4, ret, offsetR);
   }
 
-  _ssig1(Uint32List word, int offset, Uint32List ret, int offsetR) {
+  void _ssig1(Uint32List word, int offset, Uint32List ret, int offsetR) {
     _rotr(19, word, offset, _nums, _sigIndex1);
     _rotr(61, word, offset, _nums, _sigIndex2);
     _shr(6, word, offset, _nums, _sigIndex3);
@@ -190,7 +193,7 @@ abstract class _Sha64BitSink extends HashSink {
     _xor(_nums, _sigIndex1, _nums, _sigIndex4, ret, offsetR);
   }
 
-  _ch(Uint32List x, int offsetX, Uint32List y, int offsetY, Uint32List z,
+  void _ch(Uint32List x, int offsetX, Uint32List y, int offsetY, Uint32List z,
       int offsetZ, Uint32List ret, int offsetR) {
     ret[0 + offsetR] =
         ((x[0 + offsetX] & (y[0 + offsetY] ^ z[0 + offsetZ])) ^ z[0 + offsetZ]);
@@ -198,7 +201,7 @@ abstract class _Sha64BitSink extends HashSink {
         ((x[1 + offsetX] & (y[1 + offsetY] ^ z[1 + offsetZ])) ^ z[1 + offsetZ]);
   }
 
-  _maj(Uint32List x, int offsetX, Uint32List y, int offsetY, Uint32List z,
+  void _maj(Uint32List x, int offsetX, Uint32List y, int offsetY, Uint32List z,
       int offsetZ, Uint32List ret, int offsetR) {
     ret[0 + offsetR] = ((x[0 + offsetX] & (y[0 + offsetY] | z[0 + offsetZ])) |
         (y[0 + offsetY] & z[0 + offsetZ]));
@@ -274,6 +277,7 @@ abstract class _Sha64BitSink extends HashSink {
 /// This is separate so that it can extend [HashSink] without leaking additional
 /// public members.
 class Sha384Sink extends _Sha64BitSink {
+  @override
   final digestBytes = 12;
 
   Sha384Sink(Sink<Digest> sink)

--- a/lib/src/sha512_slowsinks.dart
+++ b/lib/src/sha512_slowsinks.dart
@@ -308,6 +308,7 @@ class Sha384Sink extends _Sha64BitSink {
 /// This is separate so that it can extend [HashSink] without leaking additional
 /// public members.
 class Sha512Sink extends _Sha64BitSink {
+  @override
   final digestBytes = 16;
 
   Sha512Sink(Sink<Digest> sink)

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,10 @@
 name: crypto
-version: 2.1.4
-author: Dart Team <misc@dartlang.org>
+version: 2.1.5-dev
 description: Library of cryptographic functions.
 homepage: https://www.github.com/dart-lang/crypto
 
 environment:
-  sdk: '>=2.1.0 <3.0.0'
+  sdk: '>=2.3.0 <3.0.0'
 
 dependencies:
   collection: '^1.0.0'

--- a/test/hmac_sha2_test.dart
+++ b/test/hmac_sha2_test.dart
@@ -102,7 +102,7 @@ void main() {
   });
 }
 
-testCase({
+void testCase({
   String name,
   String key,
   String data,

--- a/test/sha512_test.dart
+++ b/test/sha512_test.dart
@@ -89,10 +89,10 @@ void main() {
         'ckPYMDuPJjc73qHXQZiJgCskNG8mj9cPqFNsqYqxcBbQESgkWChoibAN7ssJrnoMFIpz9HwsBwMtt3z/KDUh9w==',
       ];
 
-      for (int i = 0; i < salts.length; i++) {
+      for (var i = 0; i < salts.length; i++) {
         var digest = <int>[];
-        for (int run = 0; run < 2000; run++) {
-          digest = sha512.convert([]..addAll(digest)..addAll(salts[i])).bytes;
+        for (var run = 0; run < 2000; run++) {
+          digest = sha512.convert([...digest, ...salts[i]]).bytes;
         }
         expect(base64.encode(digest), results[i]);
       }

--- a/test/sha_monte_test.dart
+++ b/test/sha_monte_test.dart
@@ -5,8 +5,8 @@ import 'package:crypto/crypto.dart';
 
 import 'utils.dart';
 
-main() {
-  group("Monte Vectors", () {
+void main() {
+  group('Monte Vectors', () {
     monteTest(
       'sha224',
       sha224,
@@ -56,18 +56,18 @@ main() {
   });
 }
 
-monteTest(String name, Hash hash, String seed, List<String> expected) {
+void monteTest(String name, Hash hash, String seed, List<String> expected) {
   test(name, () {
     Iterable<String> run() sync* {
       var _seed = bytesFromHexString(seed);
-      for (int j = 0; j < expected.length; j++) {
+      for (var j = 0; j < expected.length; j++) {
         Uint8List md0, md1, md2;
         md0 = (Uint8List.fromList(_seed));
         md1 = (Uint8List.fromList(_seed));
         md2 = (Uint8List.fromList(_seed));
         Digest mdI;
-        for (int i = 3; i < 1003; i++) {
-          var mI = <int>[]..addAll(md0)..addAll(md1)..addAll(md2);
+        for (var i = 3; i < 1003; i++) {
+          var mI = [...md0, ...md1, ...md2];
           mdI = hash.convert(mI);
           md0.setAll(0, md1);
           md1.setAll(0, md2);


### PR DESCRIPTION
- always_declare_return_types
- annotate_overrides
- omit_local_variable_types
- prefer_single_quotes
- prefer_spread_collections

Bump min SDK to 2.3.0 to allow spreads in collection literals.

Drop unused author field from pubspec.