### PR TITLE
Prepare for the 2.10 SDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ jobs:
     - stage: analyze_and_format
       name: "Analyze lib/"
       os: linux
-      script: dartanalyzer --enabl-experiment=non-nullable --fatal-warnings --fatal-infos lib/
+      script: dartanalyzer --enable-experiment=non-nullable --fatal-warnings --fatal-infos lib/
     - stage: analyze_and_format
       name: "Analyze test/"
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,33 @@ language: dart
 dart:
   - dev
 
-dart_task:
-  - test: --enable-experiment=non-nullable -p vm
-  - test: --enable-experiment=non-nullable -p chrome
-  - dartanalyzer: --enable-experiment=non-nullable --fatal-warnings --fatal-infos .
-
-matrix:
+jobs:
   include:
-  # Only validate formatting using the dev release
-  - dart: dev
-    dart_task: dartfmt
+    - stage: analyze_and_format
+      name: "Analyze lib/"
+      os: linux
+      script: dartanalyzer --fatal-warnings --fatal-infos lib/
+    - stage: analyze_and_format
+      name: "Analyze test/"
+      os: linux
+      script: dartanalyzer --enable-experiment=non-nullable --fatal-warnings --fatal-infos test/
+    - stage: analyze_and_format
+      name: "Format"
+      os: linux
+      script: dartfmt -n --set-exit-if-changed .
+    - stage: test
+      name: "Vm Tests"
+      os: linux
+      script: pub run --enable-experiment=non-nullable test -p vm
+    - stage: test
+      name: "Web Tests"
+      os: linux
+      script: pub run --enable-experiment=non-nullable test -p chrome
+
+stages:
+  - analyze_and_format
+  - test
+
 
 # Only building master means that we don't run two builds for each pull request.
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 language: dart
 
 dart:
-  - 2.3.0
-  - stable 
+  - dev
 
 dart_task:
-  - test: -p vm
-  - test: -p chrome
-  - dartanalyzer: --fatal-warnings --fatal-infos .
+  - test: --enable-experiment=non-nullable -p vm
+  - test: --enable-experiment=non-nullable -p chrome
+  - dartanalyzer: --enable-experiment=non-nullable --fatal-warnings --fatal-infos .
 
 matrix:
   include:
@@ -17,7 +16,7 @@ matrix:
 
 # Only building master means that we don't run two builds for each pull request.
 branches:
-  only: [master]
+  only: [master, null_safety]
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ jobs:
     - stage: analyze_and_format
       name: "Analyze lib/"
       os: linux
-      script: dartanalyzer --fatal-warnings --fatal-infos lib/
+      script: dartanalyzer --enabl-experiment=non-nullable --fatal-warnings --fatal-infos lib/
     - stage: analyze_and_format
       name: "Analyze test/"
       os: linux

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -27,7 +27,7 @@ dependency_overrides:
   convert:
     git:
       url: git://github.com/dart-lang/convert.git
-      ref: null_safety-2.10
+      ref: null_safety
   js:
     git:
       url: git://github.com/dart-lang/sdk.git

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -31,7 +31,7 @@ dependency_overrides:
   js:
     git:
       url: git://github.com/dart-lang/sdk.git
-      ref: null_safety-pkgs
+      ref: 2-10-pkgs
       path: pkg/js
   matcher:
     git: git://github.com/dart-lang/matcher.git

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: Implementations of SHA, MD5, and HMAC cryptographic functions
 homepage: https://www.github.com/dart-lang/crypto
 
 environment:
-  sdk: '>=2.9.0-1 <3.0.0'
+  sdk: '>=2.10.0-0 <2.10.0'
 
 dependencies:
   collection: '^1.0.0'
@@ -17,82 +17,60 @@ dev_dependencies:
 
 dependency_overrides:
   async:
-    git:
-      url: git://github.com/dart-lang/async.git
-      ref: null_safety
+    git: git://github.com/dart-lang/async.git
   boolean_selector:
-    git:
-      url: git://github.com/dart-lang/boolean_selector.git
-      ref: null_safety
+    git: git://github.com/dart-lang/boolean_selector.git
   charcode:
-    git:
-      url: git://github.com/dart-lang/charcode.git
-      ref: null_safety
+    git: git://github.com/dart-lang/charcode.git
   collection:
-    git:
-      url: git://github.com/dart-lang/collection.git
-      ref: null_safety
+    git: git://github.com/dart-lang/collection.git
   convert:
     git:
       url: git://github.com/dart-lang/convert.git
-      ref: null_safety
-  matcher:
-    git:
-      url: git://github.com/dart-lang/matcher.git
-      ref: null_safety
-  meta:
+      ref: null_safety-2.10
+  js:
     git:
       url: git://github.com/dart-lang/sdk.git
       ref: null_safety-pkgs
+      path: pkg/js
+  matcher:
+    git: git://github.com/dart-lang/matcher.git
+  meta:
+    git:
+      url: git://github.com/dart-lang/sdk.git
+      ref: 2-10-pkgs
       path: pkg/meta
   pedantic:
-    git:
-      url: git://github.com/dart-lang/pedantic.git
-      ref: null_safety
+    git: git://github.com/dart-lang/pedantic.git
   path:
-    git:
-      url: git://github.com/dart-lang/path.git
-      ref: null_safety
+    git: git://github.com/dart-lang/path.git
   pool:
-    git:
-      url: git://github.com/dart-lang/pool.git
-      ref: null_safety
+    git: git://github.com/dart-lang/pool.git
+  source_maps:
+    git: git://github.com/dart-lang/source_maps.git
+  source_map_stack_trace:
+    git: git://github.com/dart-lang/source_map_stack_trace.git
   source_span:
-    git:
-      url: git://github.com/dart-lang/source_span.git
-      ref: null_safety
+    git: git://github.com/dart-lang/source_span.git
   stack_trace:
-    git:
-      url: git://github.com/dart-lang/stack_trace.git
-      ref: null_safety
+    git: git://github.com/dart-lang/stack_trace.git
   stream_channel:
-    git:
-      url: git://github.com/dart-lang/stream_channel.git
-      ref: null_safety
+    git: git://github.com/dart-lang/stream_channel.git
   string_scanner:
-    git:
-      url: git://github.com/dart-lang/string_scanner.git
-      ref: null_safety
+    git: git://github.com/dart-lang/string_scanner.git
   term_glyph:
-    git:
-      url: git://github.com/dart-lang/term_glyph.git
-      ref: null_safety
+    git: git://github.com/dart-lang/term_glyph.git
   test_api:
     git:
       url: git://github.com/dart-lang/test.git
-      ref: null_safety
       path: pkgs/test_api
   test_core:
     git:
       url: git://github.com/dart-lang/test.git
-      ref: null_safety
       path: pkgs/test_core
   test:
     git:
       url: git://github.com/dart-lang/test.git
-      ref: null_safety
       path: pkgs/test
   typed_data:
-    git:
-      url: git://github.com/dart-lang/typed_data.git
-      ref: null_safety
+    git: git://github.com/dart-lang/typed_data.git


### PR DESCRIPTION
Set the min SDK to 2.10.0-0 to get a language version of 2.10.

Move dependency overrides to the master branches for the packages which
support the 2.10 SDK on the master branch.

Update travis to run the with the dev SDK and pass the
`--enable-experiment=non-nullable` flag.