### PR TITLE
Restore an assert statement

### DIFF
--- a/lib/src/digest_sink.dart
+++ b/lib/src/digest_sink.dart
@@ -20,5 +20,7 @@ class DigestSink extends Sink<Digest> {
   }
 
   @override
-  void close() {}
+  void close() {
+    assert((_value as dynamic) != null);
+  }
 }


### PR DESCRIPTION
The code prior to migration had an `assert` in the close to check that
`_value` was non-null before `close()` is called. This check _would_ be
performed by any read of `value`, but there is a very narrow window of
interaction where this is changing with the migration. In the interest
of having the smallest change possible during the migration, add back an
assert.