### PR TITLE
Bump upper bound SDK constraint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.2.0-nullsafety
+## 2.2.0-nullsafety-dev
 
 Pre-release for the null safety migration of this package.
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,10 +1,10 @@
 name: crypto
-version: 2.2.0-nullsafety
+version: 2.2.0-nullsafety-dev
 description: Implementations of SHA, MD5, and HMAC cryptographic functions
 homepage: https://www.github.com/dart-lang/crypto
 
 environment:
-  sdk: '>=2.10.0-2.0.dev <2.10.0'
+  sdk: '>=2.10.0-2.0.dev <2.11.0'
 
 dependencies:
   collection: ^1.15.0-nullsafety


### PR DESCRIPTION
The 2.11.0 dev SDK are being released, allow them for this package.

Since this package is not currently published append `-dev` to the
version string for clarity.