### PR TITLE
Clean-up of minor details. Deprecated `newInstance `methods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ This release will be pinned to only allow pre-release sdk versions starting from
 2.10.0-2.0.dev, which is the first version where this package will appear in the
 null safety allow list.
 
-  * AddsSHA-2 512/224 and SHA-2 512/256 from FIPS 180-4
+* Adds SHA-2 512/224 and SHA-2 512/256 from FIPS 180-4
+
+* Deprecates `newInstance` instance members on some classes and updates documentation.
 
 ## 2.1.5
 

--- a/lib/src/digest.dart
+++ b/lib/src/digest.dart
@@ -21,10 +21,10 @@ class Digest {
     if (other is Digest) {
       final a = bytes;
       final b = other.bytes;
-      if (a.length != b.length) {
+      final n = a.length;
+      if (n != b.length) {
         return false;
       }
-      final n = a.length;
       var mismatch = 0;
       for (var i = 0; i < n; i++) {
         mismatch |= a[i] ^ b[i];

--- a/lib/src/digest_sink.dart
+++ b/lib/src/digest_sink.dart
@@ -6,22 +6,25 @@ import 'digest.dart';
 
 /// A sink used to get a digest value out of `Hash.startChunkedConversion`.
 class DigestSink extends Sink<Digest> {
-  /// The value added to the sink, if any.
-  Digest get value => _value;
+  /// The value added to the sink.
+  ///
+  /// A value must have been added using [add] before reading the `value`.
+  Digest get value => _value!;
 
-  late final Digest _value;
+  Digest? _value;
 
   /// Adds [value] to the sink.
   ///
   /// Unlike most sinks, this may only be called once.
   @override
   void add(Digest value) {
+    assert(_value == null);
     _value = value;
   }
 
   @override
   void close() {
     // Ensure late final field was assigned before closing.
-    assert((_value as dynamic) != null);
+    assert(_value != null);
   }
 }

--- a/lib/src/hash_sink.dart
+++ b/lib/src/hash_sink.dart
@@ -25,8 +25,10 @@ abstract class HashSink implements Sink<List<int>> {
   /// used across invocations of [_iterate].
   final Uint32List _currentChunk;
 
-  /// Messages with more than 2^53-1 bits are not supported. (This is the
-  /// largest value that is representable on both JS and the Dart VM.)
+  /// Messages with more than 2^53-1 bits are not supported.
+  ///
+  /// This is the largest value that is precisely representable
+  /// on both JS and the Dart VM.
   /// So the maximum length in bytes is (2^53-1)/8.
   static const _maxMessageLengthInBytes = 0x0003ffffffffffff;
 

--- a/lib/src/md5.dart
+++ b/lib/src/md5.dart
@@ -27,8 +27,7 @@ final md5 = MD5._();
 /// **Warning**: MD5 has known collisions and should only be used when required
 /// for backwards compatibility.
 ///
-/// Note that it's almost always easier to use [md5] rather than creating a new
-/// instance.
+/// Use the [md5] object to perform MD5 hashing.
 class MD5 extends Hash {
   @override
   final int blockSize = 16 * bytesPerWord;

--- a/lib/src/sha256.dart
+++ b/lib/src/sha256.dart
@@ -28,14 +28,14 @@ final sha224 = Sha224._();
 ///
 /// [rfc]: http://tools.ietf.org/html/rfc6234
 ///
-/// Note that it's almost always easier to use [sha256] rather than creating a
-/// new instance.
+/// Use the [sha256] object to perform SHA-256 hashing.
 class Sha256 extends Hash {
   @override
   final int blockSize = 16 * bytesPerWord;
 
   Sha256._();
 
+  @deprecated
   Sha256 newInstance() => Sha256._();
 
   @override
@@ -47,14 +47,15 @@ class Sha256 extends Hash {
 ///
 /// [rfc]: http://tools.ietf.org/html/rfc6234
 ///
-/// Note that it's almost always easier to use [sha224] rather than creating a
-/// new instance.
+///
+/// Use the [sha224] object to perform SHA-224 hashing.
 class Sha224 extends Hash {
   @override
   final int blockSize = 16 * bytesPerWord;
 
   Sha224._();
 
+  @deprecated
   Sha224 newInstance() => Sha224._();
 
   @override

--- a/lib/src/sha512.dart
+++ b/lib/src/sha512.dart
@@ -42,14 +42,14 @@ const sha512256 = _Sha512256();
 ///
 /// [rfc]: http://tools.ietf.org/html/rfc6234
 ///
-/// Note that it's almost always easier to use [sha384] rather than creating a
-/// new instance.
+/// Use the [sha384] object to perform SHA-384 hashing
 class Sha384 extends Hash {
   @override
   final int blockSize = 32 * bytesPerWord;
 
   const Sha384._();
 
+  @deprecated
   Sha384 newInstance() => Sha384._();
 
   @override
@@ -61,14 +61,14 @@ class Sha384 extends Hash {
 ///
 /// [rfc]: http://tools.ietf.org/html/rfc6234
 ///
-/// Note that it's almost always easier to use [sha512] rather than creating a
-/// new instance.
+/// Use the [sha512] object to perform SHA-512 hashing
 class Sha512 extends Hash {
   @override
   final int blockSize = 32 * bytesPerWord;
 
   const Sha512._();
 
+  @deprecated
   Sha512 newInstance() => Sha512._();
 
   @override
@@ -80,8 +80,7 @@ class Sha512 extends Hash {
 ///
 /// [FIPS]: https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
 ///
-/// Note that it's almost always easier to use [sha512224] rather than creating
-/// a new instance.
+/// Use the [sha512224] object to perform SHA-512/224 hashing
 class _Sha512224 extends Hash {
   @override
   final int blockSize = 32 * bytesPerWord;
@@ -97,8 +96,7 @@ class _Sha512224 extends Hash {
 ///
 /// [FIPS]: https://nvlpubs.nist.gov/nistpubs/FIPS/NIST.FIPS.180-4.pdf
 ///
-/// Note that it's almost always easier to use [sha512256] rather than creating
-/// a new instance.
+/// Use the [sha512256] object to perform SHA-512/256 hashing
 class _Sha512256 extends Hash {
   @override
   final int blockSize = 32 * bytesPerWord;


### PR DESCRIPTION
Deprecate `newInstance` instance method on some hash classes (it's useless).
Update documentation to not say that the only available instance of the hash classes is "almost" always better to use. There is no alternative.
Clean-up on implementation of `DigestSink` to not use `late`.