### PR TITLE
Use correct SDK version

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ description: Implementations of SHA, MD5, and HMAC cryptographic functions
 homepage: https://www.github.com/dart-lang/crypto
 
 environment:
-  sdk: '>=2.12.0-dev <3.0.0'
+  sdk: '>=2.12.0-0 <3.0.0'
 
 dependencies:
   collection: ^1.15.0-nullsafety


### PR DESCRIPTION
The current SDK version on `crypto:3.0` is `>=2.12.0-dev <3.0.0`.
This makes the NNBD version of crypto unusable on most versions of dart: For example, the dart version on my computer is
```
Dart SDK version: 2.12.0-50.0.dev (dev) (Mon Nov 16 16:23:04 2020 -0800) on "macos_x64"
```
And because `"2.12.0-dev" > "2.12.0-50.0.dev"` (lexicographically), version solving fails.

Using a version that sorts before most prerelease versions, such as `2.12.0-0`, will solve this issue.