### PR TITLE
Drop dependency on package:convert

### DIFF
--- a/lib/src/digest.dart
+++ b/lib/src/digest.dart
@@ -3,7 +3,6 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:collection/collection.dart';
-import 'package:convert/convert.dart';
 
 /// A message digest as computed by a `Hash` or `HMAC` function.
 class Digest {
@@ -39,5 +38,6 @@ class Digest {
 
   /// The message digest as a string of hexadecimal digits.
   @override
-  String toString() => hex.encode(bytes);
+  String toString() =>
+      bytes.map((b) => b.toRadixString(16).padLeft(2, '0')).join('');
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,13 +8,8 @@ environment:
 
 dependencies:
   collection: ^1.15.0-nullsafety
-  convert: ^3.0.0-nullsafety
   typed_data: ^1.3.0-nullsafety
 
 dev_dependencies:
   pedantic: ^1.10.0-nullsafety
   test: ^1.16.0-nullsafety
-
-dependency_overrides:
-  convert:
-    git: git://github.com/dart-lang/convert.git


### PR DESCRIPTION
This package was only used for a hex encoder which is easy to implement
with `toRadixString`. Performance differences should not have a
meaningful impact since `Digest` should be a relatively small list of
bytes.