### PR TITLE
Fix stale links to docs

### DIFF
--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -23,7 +23,7 @@ jobs:
         sdk: [dev]
     steps:
       - uses: actions/checkout@v2
-      - uses: dart-lang/setup-dart@v0.1
+      - uses: dart-lang/setup-dart@v1.0
         with:
           channel: ${{ matrix.sdk }}
       - id: install
@@ -47,10 +47,10 @@ jobs:
       matrix:
         # Add macos-latest and/or windows-latest if relevant for this package.
         os: [ubuntu-latest]
-        sdk: [dev]
+        sdk: [2.12.0, dev]
     steps:
       - uses: actions/checkout@v2
-      - uses: dart-lang/setup-dart@v0.1
+      - uses: dart-lang/setup-dart@v1.0
         with:
           channel: ${{ matrix.sdk }}
       - id: install

--- a/.github/workflows/test-package.yml
+++ b/.github/workflows/test-package.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1.0
         with:
-          channel: ${{ matrix.sdk }}
+          sdk: ${{ matrix.sdk }}
       - id: install
         name: Install dependencies
         run: dart pub get
@@ -52,7 +52,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: dart-lang/setup-dart@v1.0
         with:
-          channel: ${{ matrix.sdk }}
+          sdk: ${{ matrix.sdk }}
       - id: install
         name: Install dependencies
         run: dart pub get

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.0.1
+
+* Fix doc links in README.
+
 ## 3.0.0
 
 * Stable release for null safety.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ This library has not been reviewed or vetted by security professionals.
 [convert]: https://pub.dev/documentation/crypto/latest/crypto/Hash/convert.html
 [Digest]: https://pub.dev/documentation/crypto/latest/crypto/Digest-class.html
 [Hmac]: https://pub.dev/documentation/crypto/latest/crypto/Hmac-class.html
-[md5-obj]: https://pub.dev/documentation/crypto/latest/crypto/md5.html
-[sha1-obj]: https://pub.dev/documentation/crypto/latest/crypto/sha1.html
-[sha256-obj]: https://pub.dev/documentation/crypto/latest/crypto/sha256.html
+[md5-obj]: https://pub.dev/documentation/crypto/latest/crypto/md5-constant.html
+[sha1-obj]: https://pub.dev/documentation/crypto/latest/crypto/sha1-constant.html
+[sha256-obj]: https://pub.dev/documentation/crypto/latest/crypto/sha256-constant.html
 [startChunkedConversion]: https://pub.dev/documentation/crypto/latest/crypto/Hash/startChunkedConversion.html

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,15 +1,15 @@
 name: crypto
-version: 3.0.0
+version: 3.0.1
 description: Implementations of SHA, MD5, and HMAC cryptographic functions
-homepage: https://www.github.com/dart-lang/crypto
+repository: https://www.github.com/dart-lang/crypto
 
 environment:
-  sdk: '>=2.12.0-0 <3.0.0'
+  sdk: '>=2.12.0 <3.0.0'
 
 dependencies:
   collection: ^1.15.0
   typed_data: ^1.3.0
 
 dev_dependencies:
-  pedantic: ^1.10.0-nullsafety
-  test: ^1.16.0-nullsafety
+  pedantic: ^1.10.0
+  test: ^1.16.0


### PR DESCRIPTION
Closes #114

The URL format was updated on the pub site to a `-constant` suffix.

Cleanup:
- Use v1.0 of the Dart setup Github action.
- Test on the oldest supported SDK.
- Change the pubspec `homepage` config to `repository`.
- Use stable versions of dev dependencies.