### PR TITLE
Move from pedantic to lints package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.0.2-dev
+
 ## 3.0.1
 
 * Fix doc links in README.

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,4 +1,4 @@
-include: package:pedantic/analysis_options.1.9.0.yaml
+include: package:lints/recommended.yaml
 linter:
   rules:
     - avoid_empty_else

--- a/lib/src/hash.dart
+++ b/lib/src/hash.dart
@@ -22,10 +22,10 @@ abstract class Hash extends Converter<List<int>, Digest> {
   const Hash();
 
   @override
-  Digest convert(List<int> data) {
+  Digest convert(List<int> input) {
     var innerSink = DigestSink();
     var outerSink = startChunkedConversion(innerSink);
-    outerSink.add(data);
+    outerSink.add(input);
     outerSink.close();
     return innerSink.value;
   }

--- a/lib/src/hmac.dart
+++ b/lib/src/hmac.dart
@@ -38,10 +38,10 @@ class Hmac extends Converter<List<int>, Digest> {
   }
 
   @override
-  Digest convert(List<int> data) {
+  Digest convert(List<int> input) {
     var innerSink = DigestSink();
     var outerSink = startChunkedConversion(innerSink);
-    outerSink.add(data);
+    outerSink.add(input);
     outerSink.close();
     return innerSink.value;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: crypto
-version: 3.0.1
+version: 3.0.2-dev
 description: Implementations of SHA, MD5, and HMAC cryptographic functions
 repository: https://www.github.com/dart-lang/crypto
 
@@ -11,5 +11,5 @@ dependencies:
   typed_data: ^1.3.0
 
 dev_dependencies:
-  pedantic: ^1.10.0
+  lints: ^1.0.0
   test: ^1.16.0


### PR DESCRIPTION
Fix existing violations of the lint `avoid_renaming_method_parameters`.