### PR TITLE
Remove 'www' subdomain in repository url

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: crypto
 version: 3.0.2-dev
 description: Implementations of SHA, MD5, and HMAC cryptographic functions
-repository: https://www.github.com/dart-lang/crypto
+repository: https://github.com/dart-lang/crypto
 
 environment:
   sdk: '>=2.12.0 <3.0.0'


### PR DESCRIPTION
The 'www' subdomain of 'github.com' is not needed and can confuse some tooling that simply looks for 'github.com'. All other dart-team packages I looked at don't use 'www'.