### PR TITLE
Add Wasm support

### DIFF
--- a/lib/src/sha512.dart
+++ b/lib/src/sha512.dart
@@ -7,7 +7,8 @@ import 'dart:convert';
 import 'digest.dart';
 import 'hash.dart';
 // ignore: uri_does_not_exist
-import 'sha512_fastsinks.dart' if (dart.library.js_interop) 'sha512_slowsinks.dart';
+import 'sha512_fastsinks.dart'
+    if (dart.library.js_interop) 'sha512_slowsinks.dart';
 import 'utils.dart';
 
 /// An implementation of the [SHA-384][rfc] hash function.

--- a/lib/src/sha512.dart
+++ b/lib/src/sha512.dart
@@ -7,7 +7,7 @@ import 'dart:convert';
 import 'digest.dart';
 import 'hash.dart';
 // ignore: uri_does_not_exist
-import 'sha512_fastsinks.dart' if (dart.library.html) 'sha512_slowsinks.dart';
+import 'sha512_fastsinks.dart' if (dart.library.js_interop) 'sha512_slowsinks.dart';
 import 'utils.dart';
 
 /// An implementation of the [SHA-384][rfc] hash function.


### PR DESCRIPTION
Since dart:html is not supported when compiling to Wasm, the correct alternative now is to use dart.library.js_interop to differentiate between native and web

Source:
https://dart.dev/interop/js-interop/package-web

- Thanks for your contribution! Please replace this text with a description of what this PR is changing or adding and why, list any relevant issues, and review the contribution guidelines below.

---

- [ ] I’ve reviewed the contributor guide and applied the relevant portions to this PR.

<details>
  <summary>Contribution guidelines:</summary><br>

- See our [contributor guide](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md) for general expectations for PRs.
- Larger or significant changes should be discussed in an issue before creating a PR.
- Contributions to our repos should follow the [Dart style guide](https://dart.dev/guides/language/effective-dart) and use `dart format`.
- Most changes should add an entry to the changelog and may need to [rev the pubspec package version](https://github.com/dart-lang/sdk/blob/main/docs/External-Package-Maintenance.md#making-a-change).
- Changes to packages require [corresponding tests](https://github.com/dart-lang/.github/blob/main/CONTRIBUTING.md#Testing).

Note that many Dart repos have a weekly cadence for reviewing PRs - please allow for some latency before initial review feedback.
</details>
