### PR TITLE
Revert wasm using fast path due to dart-lang/sdk/issues/55266

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 3.0.5
+
+* Revert switch to enable fast "sinks" on Wasm because it breaks `dart2js` with
+  server mode.
+
 ## 3.0.4
 
 * Fix WebAssembly support.

--- a/lib/src/sha512.dart
+++ b/lib/src/sha512.dart
@@ -7,7 +7,7 @@ import 'dart:convert';
 import 'digest.dart';
 import 'hash.dart';
 // ignore: uri_does_not_exist
-import 'sha512_fastsinks.dart' if (dart.library.html) 'sha512_slowsinks.dart';
+import 'sha512_fastsinks.dart' if (dart.library.js) 'sha512_slowsinks.dart';
 import 'utils.dart';
 
 /// An implementation of the [SHA-384][rfc] hash function.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: crypto
-version: 3.0.4
+version: 3.0.5
 description: Implementations of SHA, MD5, and HMAC cryptographic functions.
 repository: https://github.com/dart-lang/crypto
 topics:


### PR DESCRIPTION
Preparing to publish 3.0.5

Revert "Switch sha512 to use fastpath with wasm (#165)"

This reverts commit 69d13c9903d4134582ce1bbd9a31cfd8a510c22d.
